### PR TITLE
Not in Implementation

### DIFF
--- a/spec/Condition/NotInSpec.php
+++ b/spec/Condition/NotInSpec.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace spec\Rb\Specification\Doctrine\Condition;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use PhpSpec\ObjectBehavior;
+use Rb\Specification\Doctrine\SpecificationInterface;
+
+class NotInSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $value = ['bar', 'baz'];
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->value);
+    }
+
+    public function it_is_an_expression()
+    {
+        $this->shouldBeAnInstanceOf(SpecificationInterface::class);
+    }
+
+    public function it_returns_an_expression_func_object(QueryBuilder $queryBuilder, ArrayCollection $parameters, Expr $expr)
+    {
+        $dqlAlias   = 'a';
+        $expression = 'a.foo not in(:not_in_10)';
+
+        $queryBuilder->expr()->willReturn($expr);
+        $expr->notIn(sprintf('%s.%s', $dqlAlias, $this->field), ':not_in_10')->willReturn($expression);
+
+        $queryBuilder->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $queryBuilder->setParameter('not_in_10', $this->value)->shouldBeCalled();
+        $this->isSatisfiedBy('foo')->shouldReturn(true);
+        $this->modify($queryBuilder, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_should_use_dql_alias_if_set(QueryBuilder $queryBuilder, ArrayCollection $parameters, Expr $expr)
+    {
+        $dqlAlias   = 'x';
+        $expression = 'x.foo not in(:not_in_10)';
+
+        $this->beConstructedWith($this->field, $this->value, $dqlAlias);
+
+        $queryBuilder->expr()->willReturn($expr);
+        $expr->notIn(sprintf('%s.%s', $dqlAlias, $this->field), ':not_in_10')->willReturn($expression);
+
+        $queryBuilder->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $queryBuilder->setParameter('not_in_10', $this->value)->shouldBeCalled();
+        $this->isSatisfiedBy('foo')->shouldReturn(true);
+        $this->modify($queryBuilder, $dqlAlias)->shouldReturn($expression);
+    }
+}

--- a/spec/Condition/NotInSpec.php
+++ b/spec/Condition/NotInSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
+use Rb\Specification\Doctrine\Condition\In;
 use Rb\Specification\Doctrine\SpecificationInterface;
 
 class NotInSpec extends ObjectBehavior
@@ -22,6 +23,7 @@ class NotInSpec extends ObjectBehavior
     public function it_is_an_expression()
     {
         $this->shouldBeAnInstanceOf(SpecificationInterface::class);
+        $this->shouldBeAnInstanceOf(In::class);
     }
 
     public function it_returns_an_expression_func_object(QueryBuilder $queryBuilder, ArrayCollection $parameters, Expr $expr)

--- a/spec/SpecificationRepositorySpec.php
+++ b/spec/SpecificationRepositorySpec.php
@@ -89,13 +89,13 @@ class SpecificationRepositorySpec extends ObjectBehavior
         $entityManager->createQueryBuilder()->willReturn($queryBuilder);
 
         $queryBuilder->select($this->dqlAlias)->willReturn($queryBuilder);
-        $queryBuilder->from(Argument::any(), $this->dqlAlias)->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::any(), $this->dqlAlias, Argument::any())->willReturn($queryBuilder);
         $queryBuilder->where(Argument::any())->shouldNotBeCalled();
         $queryBuilder->getQuery()->willReturn($query);
 
-        $specification->modify($queryBuilder, $this->dqlAlias)->shouldBeCalled();
+        $specification->modify($queryBuilder, $this->dqlAlias, Argument::any())->shouldBeCalled();
         $specification->isSatisfiedBy(Argument::any())->willReturn(true);
-        $specification->modify($queryBuilder, $this->dqlAlias)->willReturn('');
+        $specification->modify($queryBuilder, $this->dqlAlias, Argument::any())->willReturn('');
 
         $this->match($specification);
     }
@@ -119,7 +119,7 @@ class SpecificationRepositorySpec extends ObjectBehavior
         $specification->modify($queryBuilder, $this->dqlAlias)->willReturn($this->expression);
 
         $queryBuilder->select($this->dqlAlias)->willreturn($queryBuilder);
-        $queryBuilder->from(Argument::any(), $this->dqlAlias)->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::any(), $this->dqlAlias, Argument::any())->willReturn($queryBuilder);
         $queryBuilder->where($this->expression)->willReturn($queryBuilder);
 
         $queryBuilder->getQuery()->willReturn($query);

--- a/src/Condition/In.php
+++ b/src/Condition/In.php
@@ -43,7 +43,7 @@ class In extends AbstractSpecification
      *
      * @return string
      */
-    private function generateParameterName(QueryBuilder $queryBuilder)
+    protected function generateParameterName(QueryBuilder $queryBuilder)
     {
         return sprintf('in_%d', count($queryBuilder->getParameters()));
     }

--- a/src/Condition/In.php
+++ b/src/Condition/In.php
@@ -43,7 +43,7 @@ class In extends AbstractSpecification
      *
      * @return string
      */
-    protected function generateParameterName(QueryBuilder $queryBuilder)
+    private function generateParameterName(QueryBuilder $queryBuilder)
     {
         return sprintf('in_%d', count($queryBuilder->getParameters()));
     }

--- a/src/Condition/NotIn.php
+++ b/src/Condition/NotIn.php
@@ -16,4 +16,14 @@ class NotIn extends In
             sprintf(':%s', $paramName)
         );
     }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     *
+     * @return string
+     */
+    protected function generateParameterName(QueryBuilder $queryBuilder)
+    {
+        return sprintf('not_in_%d', count($queryBuilder->getParameters()));
+    }
 }

--- a/src/Condition/NotIn.php
+++ b/src/Condition/NotIn.php
@@ -22,7 +22,7 @@ class NotIn extends In
      *
      * @return string
      */
-    protected function generateParameterName(QueryBuilder $queryBuilder)
+    private function generateParameterName(QueryBuilder $queryBuilder)
     {
         return sprintf('not_in_%d', count($queryBuilder->getParameters()));
     }

--- a/src/Condition/NotIn.php
+++ b/src/Condition/NotIn.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rb\Specification\Doctrine\Condition;
+
+use Doctrine\ORM\QueryBuilder;
+
+class NotIn extends In
+{
+    public function modify(QueryBuilder $queryBuilder, $dqlAlias)
+    {
+        $paramName = $this->generateParameterName($queryBuilder);
+        $queryBuilder->setParameter($paramName, $this->value);
+
+        return (string) $queryBuilder->expr()->notIn(
+            $this->createPropertyWithAlias($dqlAlias),
+            sprintf(':%s', $paramName)
+        );
+    }
+}


### PR DESCRIPTION
I see that **not in** was not included.
I created a Specification, with test, that extend In to include the functionality

On my machine there was three stubs that was not working. See spec/SpecificationRepositorySpec.php.
The EntityRepository method gets three parameters, and so it failed. Let me know if it's ok like this...
