### PR TITLE
Add support for select() QueryBuilder method in Select specification

### DIFF
--- a/spec/Query/SelectSpec.php
+++ b/spec/Query/SelectSpec.php
@@ -4,6 +4,8 @@ namespace spec\Rb\Specification\Doctrine\Query;
 
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
+use Rb\Specification\Doctrine\Exception\InvalidArgumentException;
+use Rb\Specification\Doctrine\Query\Select;
 
 class SelectSpec extends ObjectBehavior
 {
@@ -11,11 +13,36 @@ class SelectSpec extends ObjectBehavior
     {
         $alias  = 'a';
         $entity = 'foo';
-        $this->beConstructedWith($entity);
+        $type = Select::ADD_SELECT;
+        $this->beConstructedWith($entity, $type);
 
         $queryBuilder->addSelect($entity)->shouldBeCalled();
 
         $this->isSatisfiedBy('foo')->shouldReturn(true);
         $this->modify($queryBuilder, $alias);
+    }
+
+    public function it_should_replace_selects_in_query_builder(QueryBuilder $queryBuilder)
+    {
+        $alias  = 'a';
+        $entity = 'foo';
+        $type = Select::SELECT;
+        $this->beConstructedWith($entity, $type);
+
+        $queryBuilder->select($entity)->shouldBeCalled();
+
+        $this->isSatisfiedBy('foo')->shouldReturn(true);
+        $this->modify($queryBuilder, $alias);
+    }
+
+    public function it_throws_an_exception_when_setting_illegal_type()
+    {
+        $entity = 'foo';
+        $this->beConstructedWith($entity);
+        
+        $this->setType(Select::ADD_SELECT);
+
+        $this->shouldThrow(InvalidArgumentException::class)
+            ->during('setType', ['foo']);
     }
 }

--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -3,6 +3,7 @@
 namespace Rb\Specification\Doctrine\Query;
 
 use Doctrine\ORM\QueryBuilder;
+use Rb\Specification\Doctrine\Exception\InvalidArgumentException;
 use Rb\Specification\Doctrine\SpecificationInterface;
 
 /**
@@ -10,16 +11,28 @@ use Rb\Specification\Doctrine\SpecificationInterface;
  */
 class Select implements SpecificationInterface
 {
+    const SELECT     = 'select';
+    const ADD_SELECT = 'addSelect';
+
+    protected static $types = [self::SELECT, self::ADD_SELECT];
+
     /**
      * @var string|array
      */
     protected $select;
 
     /**
-     * @param string|array $select
+     * @var string
      */
-    public function __construct($select)
+    protected $type;
+
+    /**
+     * @param string|array $select
+     * @param string       $type
+     */
+    public function __construct($select, $type = self::ADD_SELECT)
     {
+        $this->setType($type);
         $this->select = $select;
     }
 
@@ -28,7 +41,25 @@ class Select implements SpecificationInterface
      */
     public function modify(QueryBuilder $queryBuilder, $dqlAlias)
     {
-        $queryBuilder->addSelect($this->select);
+        call_user_func_array([$queryBuilder, $this->type], [$this->select]);
+    }
+
+    /**
+     * @param string $type
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setType($type)
+    {
+        if (!in_array($type, self::$types, true)) {
+            throw new InvalidArgumentException(sprintf(
+                '"%s" is not a valid type! Valid types: %s',
+                $type,
+                implode(', ', self::$types)
+            ));
+        }
+
+        $this->type = $type;
     }
 
     /**


### PR DESCRIPTION
Adds the ability to use the QueryBuilder's `select()` method too, not just `addSelect()`.
