### PR TITLE
Have setType() return $this to realize fluent setter

### DIFF
--- a/src/Query/Join.php
+++ b/src/Query/Join.php
@@ -60,6 +60,8 @@ class Join extends AbstractSpecification
     /**
      * @param string $type
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException
      */
     public function setType($type)
@@ -73,6 +75,8 @@ class Join extends AbstractSpecification
         }
 
         $this->type = $type;
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This would allow:

```php
new Specification([
    (new Join('x','y'))->setType(Join::INNER_JOIN)
]);
```