### PR TITLE
SpecificationRepository as trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "psr-4": {"Rb\\Specification\\Doctrine\\": "src/"}
   },
   "autoload-dev": {
-    "psr-4": {"spec\\Rb\\Specification\\Doctrine\\": "spec/"}
+    "psr-4": {"spec\\Rb\\Specification\\Doctrine\\": "spec/"},
+    "files": ["spec/SpecificationRepositoryStub.php"]
   },
   "require": {
     "php": ">=5.5",

--- a/spec/SpecificationRepositorySpec.php
+++ b/spec/SpecificationRepositorySpec.php
@@ -22,6 +22,7 @@ class SpecificationRepositorySpec extends ObjectBehavior
 
     public function let(EntityManager $entityManager, ClassMetadata $classMetadata)
     {
+        $this->beAnInstanceOf('Rb\Specification\Doctrine\SpecificationRepositoryStub');
         $this->beConstructedWith($entityManager, $classMetadata);
     }
 

--- a/spec/SpecificationRepositoryStub.php
+++ b/spec/SpecificationRepositoryStub.php
@@ -4,7 +4,7 @@ namespace Rb\Specification\Doctrine;
 
 use Doctrine\ORM\EntityRepository;
 
-class SpecificationRepositoryStub extends EntityRepository
+class SpecificationRepositoryStub extends EntityRepository implements SpecificationAware
 {
     use SpecificationRepositoryTrait;
 }

--- a/spec/SpecificationRepositoryStub.php
+++ b/spec/SpecificationRepositoryStub.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rb\Specification\Doctrine;
+
+use Doctrine\ORM\EntityRepository;
+
+class SpecificationRepositoryStub extends EntityRepository
+{
+    use SpecificationRepositoryTrait;
+}

--- a/src/SpecificationAware.php
+++ b/src/SpecificationAware.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rb\Specification\Doctrine;
+
+use Doctrine\ORM\Query;
+use Rb\Specification\Doctrine\Result\ModifierInterface;
+
+/**
+ * SpecificationAware can be used to implement custom repository.
+ */
+interface SpecificationAware
+{
+    /**
+     * Get the query after matching with given specification.
+     *
+     * @param SpecificationInterface $specification
+     * @param ModifierInterface      $modifier
+     *
+     * @return Query
+     */
+    public function match(SpecificationInterface $specification, ModifierInterface $modifier = null);
+}

--- a/src/SpecificationRepositoryTrait.php
+++ b/src/SpecificationRepositoryTrait.php
@@ -2,21 +2,20 @@
 
 namespace Rb\Specification\Doctrine;
 
-use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Rb\Specification\Doctrine\Exception\LogicException;
 use Rb\Specification\Doctrine\Result\ModifierInterface;
 
 /**
- * Class SpecificationRepository.
+ * Class SpecificationRepositoryTrait.
  */
-class SpecificationRepository extends EntityRepository
+trait SpecificationRepositoryTrait
 {
     /**
      * @var string
      */
-    private $dqlAlias = 'e';
+    protected $dqlAlias = 'e';
 
     /**
      * Get the query after matching with given specification.

--- a/src/SpecificationRepositoryTrait.php
+++ b/src/SpecificationRepositoryTrait.php
@@ -18,14 +18,13 @@ trait SpecificationRepositoryTrait
     protected $dqlAlias = 'e';
 
     /**
-     * Get the query after matching with given specification.
+     * @see SpecificationAware::match()
      *
      * @param SpecificationInterface $specification
-     * @param ModifierInterface      $modifier
-     *
-     * @throws LogicException
+     * @param ModifierInterface|null $modifier
      *
      * @return Query
+     * @throws LogicException
      */
     public function match(SpecificationInterface $specification, ModifierInterface $modifier = null)
     {


### PR DESCRIPTION
I second @juliangut as in #17 to make the SpecificationRepository as a trait, in order to be used in other repositories.